### PR TITLE
:bare => true in compilation options

### DIFF
--- a/lib/coffeebeans.rb
+++ b/lib/coffeebeans.rb
@@ -9,7 +9,7 @@ module CoffeeBeans
 
       def self.call(template)
         compiled_source = erb_handler.call(template)
-        "::CoffeeScript.compile(begin;#{compiled_source};end)"
+        "::CoffeeScript.compile(begin;#{compiled_source};end, :bare => true)"
       end
     end
   end


### PR DESCRIPTION
Had to add `:bare => true` into the CoffeeScript compile call because without it I was not getting correct renderings on my scripts. For example, something like this:

```
<% @comments.each do |comment| %>
$('#comments').append '<%= escape_javascript render(comment) %>'
<% end %>

# Update offset
$('#comments').data 'offset', <%= @offset %>
```

would only render the appends, and not the last JS (`$('#comments').data 'offset', <%= @offset %>`). 

Hope this helps!
