### PR TITLE
here's the fix to make including .coffee files from .js.erb not require a raw

### DIFF
--- a/lib/coffeebeans.rb
+++ b/lib/coffeebeans.rb
@@ -9,23 +9,23 @@ module CoffeeBeans
 
       def self.call(template)
         compiled_source = erb_handler.call(template)
-        "::CoffeeScript.compile(begin;#{compiled_source};end)"
+        "::CoffeeScript.compile(begin;#{compiled_source};end).html_safe"
       end
     end
   end
-  
+
   module ViewHelpers
-    
+
     def coffee_script_tag(&block)
       content_tag(:script, coffee_script(&block), :type => 'text/javascript')
     end
-    
+
     def coffee_script(&block)
       ::CoffeeScript.compile(capture(&block)).html_safe
     end
-    
+
   end
-  
+
 end
 
 ActionView::Template.register_template_handler :coffee, CoffeeBeans::Handlers::CoffeeScript


### PR DESCRIPTION
commit ac6115a2571e690ef2b4c09512b835ba68722e6f
Author: Ram Dobson ram.dobson@solsystemscompany.com
Date:   Thu Jan 26 10:51:25 2012 -0500

```
add html_safe after compile to fix partials
```
